### PR TITLE
docs: expand README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,65 @@
 # Site Projects
 
-+ Request your access for contribtion of this site, or make a fork.
+Repositorio del sitio web estático construido con [Hugo](https://gohugo.io/) y el tema
+[hugo-winston-theme](https://github.com/zerostaticthemes/hugo-winston-theme).
+Este proyecto alimenta la galería de proyectos y blog alojados bajo el nombre
+"Proyectos".
 
-## Install Hugo
+## Requisitos previos
 
-command:
+- [Hugo Extended](https://gohugo.io/installation/)
+- [Git](https://git-scm.com/)
 
-```bash
-    brew install hugo
-```
+## Clonar el repositorio
 
-## Install Site
-
-command:
-
-```bash
-    git init
-    hugo install theme
-```
-
-## Run dev
+Incluye el tema como un submódulo de Git, por lo que es recomendable clonar
+recursivamente:
 
 ```bash
-    hugo server --environment development
+git clone --recursive <url-del-repositorio>
+cd projects
 ```
+
+Si ya clonaste el repositorio sin submódulos ejecuta:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Desarrollo local
+
+Inicia un servidor de desarrollo con recarga en vivo:
+
+```bash
+hugo server --environment development
+```
+
+## Generar el sitio para producción
+
+```bash
+hugo --environment production
+```
+
+Los archivos generados quedarán en la carpeta `public/`.
+
+## Estructura del proyecto
+
+- `content/`: Entradas del blog y páginas.
+- `layouts/`: Plantillas y componentes de diseño.
+- `assets/`: Recursos procesados por Hugo (por ejemplo, Sass).
+- `static/`: Archivos estáticos servidos tal cual (imágenes, JS, etc.).
+- `config/` y `hugo.toml`: Configuración del sitio.
+- `themes/`: Submódulo con el tema.
+
+## Contribuir
+
+1. Haz un fork del repositorio.
+2. Crea una rama para tu cambio.
+3. Envía un Pull Request describiendo tu contribución.
+
+Si deseas acceso directo para contribuir, solicita permisos al mantenedor.
+
+## Licencia
+
+Este repositorio no incluye un archivo de licencia. Considera agregar uno si
+piensas distribuir el código públicamente.


### PR DESCRIPTION
## Summary
- document prerequisites and theme submodule setup
- add local development and production build commands
- outline repository structure and contribution steps

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b20a6ff5748322aa58ed52f9ea05ca